### PR TITLE
[MNT] Add summer course link in main website

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,7 @@ precio: 2520
 		<div class="edition">
 			<h2>Máster UCLM - {{ page.edicion }}ª Edición</h2>
 		</div>
+		<p id="block-inscribete"> <a id="btn-inscribete" href="https://eventos.uclm.es/81131/section/36691/ciencia-de-datos-impacto-en-la-sociedad.html" target="_blank">Curso de verano 22 y 23 de junio</a> </p>
 	</div>
 </section>
 


### PR DESCRIPTION
This pull request add the summer course link to the main `CiDAEN` website.